### PR TITLE
changing the workflow of the defaultmodel plugin

### DIFF
--- a/extensions/defaultmodel/DefaultmodelPlugin.php
+++ b/extensions/defaultmodel/DefaultmodelPlugin.php
@@ -18,6 +18,12 @@ class DefaultmodelPlugin extends OntoWiki_Plugin
 {
     public function onAfterInitController($event)
     {
+        //this extension should only run if no explicit model is given via request parameter "m"
+        $request = new Zend_Controller_Request_Http();
+        if ($request->get("m")) {
+            return;
+        }
+
         $config = $this->_privateConfig->toArray();
         $efApp  = Erfurt_App::getInstance();
 


### PR DESCRIPTION
now the configured iri is only to be used if no parameter "m" is given in the request
