### PR TITLE
Fix #152. Move menu creation to Menu_Registry.

### DIFF
--- a/application/classes/OntoWiki/Menu.php
+++ b/application/classes/OntoWiki/Menu.php
@@ -82,7 +82,7 @@ class OntoWiki_Menu
         }
 
         if (array_key_exists($entryKey, $this->_entries)) {
-            throw new OntoWiki_Exception("An entry with key '$key' already exists.");
+            throw new OntoWiki_Exception("An entry with key '$entryKey' already exists.");
         }
 
         if ($entryKey == self::SEPARATOR) {

--- a/application/classes/OntoWiki/Menu/Registry.php
+++ b/application/classes/OntoWiki/Menu/Registry.php
@@ -2,7 +2,7 @@
 /**
  * This file is part of the {@link http://ontowiki.net OntoWiki} project.
  *
- * @copyright Copyright (c) 2012, {@link http://aksw.org AKSW}
+ * @copyright Copyright (c) 2013, {@link http://aksw.org AKSW}
  * @license   http://opensource.org/licenses/gpl-license.php GNU General Public License (GPL)
  */
 
@@ -53,17 +53,26 @@ class OntoWiki_Menu_Registry
      *
      * @return OntoWiki_Menu
      */
-    public function getMenu($menuKey)
+    public function getMenu($menuKey, $context = null)
     {
         if (!is_string($menuKey)) {
             throw new OntoWiki_Exception('Menu key must be string.');
         }
 
-        if (!array_key_exists($menuKey, $this->_menus)) {
-            $this->setMenu($menuKey, new OntoWiki_Menu());
+        if (!isset($this->_menus[$context])) {
+            $this->_menus[$context] = array();
         }
 
-        return $this->_menus[$menuKey];
+        if (!array_key_exists($menuKey, $this->_menus[$context])) {
+            $getMethod = '_get' . ucfirst($menuKey) . 'Menu';
+            if (method_exists($this, $getMethod)) {
+                $this->setMenu($menuKey, $context, $this->$getMethod($context));
+            } else {
+                $this->setMenu($menuKey, $context, new OntoWiki_Menu());
+            }
+        }
+
+        return $this->_menus[$context][$menuKey];
     }
 
     /**
@@ -75,27 +84,41 @@ class OntoWiki_Menu_Registry
      *
      * @return OntoWiki_Menu_Registry
      */
-    public function setMenu($menuKey, OntoWiki_Menu $menu, $replace = true)
+    public function setMenu($menuKey, $context, OntoWiki_Menu $menu, $replace = true)
     {
         if (!is_string($menuKey)) {
             throw new OntoWiki_Exception('Menu key must be string.');
         }
 
-        if (!$replace && array_key_exists($menuKey, $this->menus)) {
+        if (!isset($this->_menus[$context])) {
+            $this->_menus[$context] = array();
+        }
+
+        if (!$replace && array_key_exists($menuKey, $this->_menus[$context])) {
             throw new OntoWiki_Exception("Menu with key '$menuKey' already registered.");
         }
 
-        $this->_menus[$menuKey] = $menu;
+        $this->_menus[$context][$menuKey] = $menu;
 
         return $this;
     }
 
     private function __construct()
     {
-        $this->setMenu('application', $this->_getApplicationMenu());
+        $owApp = OntoWiki::getInstance();
+        $this->setMenu('application', null, $this->_getApplicationMenu());
+
+        // check if a resource is selected
+        if (isset($owApp->selectedResource) && $owApp->selectedResource) {
+            $resource = (string)$owApp->selectedResource;
+            $this->setMenu('resource', $resource, $this->_getResourceMenu($resource));
+        }
     }
 
-    private function _getApplicationMenu()
+    /**
+     * Create the application menu and fill it with its default entries
+     */
+    private function _getApplicationMenu($context = null)
     {
         $owApp = OntoWiki::getInstance();
 
@@ -170,6 +193,230 @@ class OntoWiki_Menu_Registry
 
         return $applicationMenu;
     }
+
+    /**
+     * Create the context menu for models/knowledge bases and fill it with its default entries
+     */
+    private function _getModelMenu($model = null)
+    {
+        $owApp = OntoWiki::getInstance();
+        if ($model === null) {
+            $model = $owApp->selectedModel;
+        }
+        $config = $owApp->config;
+
+        $modelMenu = new OntoWiki_Menu();
+
+        // Select Knowledge Base
+        $url = new OntoWiki_Url(
+            array('controller' => 'model', 'action' => 'select'),
+            array()
+        );
+        $url->setParam('m', $model, false);
+        $modelMenu->appendEntry(
+            'Select Knowledge Base',
+            (string)$url
+        );
+
+        // check if model could be edited (prefixes and data)
+        if ($owApp->erfurt->getAc()->isModelAllowed('edit', $model)) {
+            // Configure Knowledge Base
+            $url = new OntoWiki_Url(
+                array('controller' => 'model', 'action' => 'config'),
+                array()
+            );
+            $url->setParam('m', $model, false);
+            $modelMenu->appendEntry(
+                'Configure Knowledge Base',
+                (string)$url
+            );
+
+            // Add Data to Knowledge Base
+            $url = new OntoWiki_Url(
+                array('controller' => 'model', 'action' => 'add'),
+                array()
+            );
+            $url->setParam('m', $model, false);
+            $modelMenu->appendEntry(
+                'Add Data to Knowledge Base',
+                (string)$url
+            );
+        }
+
+        // Model export
+        if ($owApp->erfurt->getAc()->isActionAllowed(Erfurt_Ac_Default::ACTION_MODEL_EXPORT)) {
+            // add entries for supported export formats
+            foreach (Erfurt_Syntax_RdfSerializer::getSupportedFormats() as $key => $format) {
+
+                $url = new OntoWiki_Url(
+                    array('controller' => 'model', 'action' => 'export'),
+                    array()
+                );
+                $url->setParam('m', $model, false);
+                $url->setParam('f', $key);
+
+                $modelMenu->appendEntry(
+                    'Export Knowledge Base as ' . $format,
+                    (string)$url
+                );
+            }
+        }
+
+        // can user delete models?
+        if (
+            $owApp->erfurt->getAc()->isModelAllowed('edit', $model)
+            && $owApp->erfurt->getAc()->isActionAllowed('ModelManagement')
+        ) {
+
+            $url = new OntoWiki_Url(
+                array('controller' => 'model', 'action' => 'delete'),
+                array()
+            );
+            $url->setParam('model', $model, false);
+
+            $modelMenu->appendEntry(
+                'Delete Knowledge Base',
+                (string)$url
+            );
+        }
+
+        // add a seperator
+        $modelMenu->appendEntry(OntoWiki_Menu::SEPARATOR);
+
+        return $modelMenu;
+    }
+
+    /**
+     * Create the (context) menu for resource and fill it with its default entries
+     */
+    private function _getResourceMenu($resource = null)
+    {
+        $owApp = OntoWiki::getInstance();
+        if ($resource === null) {
+            $resource = $owApp->selectedResource;
+        }
+        $config = $owApp->config;
+
+        $resourceMenu = new OntoWiki_Menu();
+
+        // Add the class Menu if the current resource is a class
+        $classMenu = $this->_getClassMenu($resource)->toArray();
+        foreach ($classMenu as $key => $value) {
+            $resourceMenu->appendEntry($key, $value);
+        }
+        if (count($classMenu) > 0) {
+            $resourceMenu->appendEntry(OntoWiki_Menu::SEPARATOR);
+        }
+
+        // View resource
+        $url = new OntoWiki_Url(
+            array('action' => 'view'),
+            array()
+        );
+        $url->setParam('r', $resource, true);
+
+        $resourceMenu->appendEntry(
+            'View Resource',
+            (string)$url
+        );
+
+        // Edit entries
+        if ($owApp->erfurt->getAc()->isModelAllowed('edit', $owApp->selectedModel)) {
+            // edit resource option
+            $resourceMenu->appendEntry(
+                'Edit Resource',
+                'javascript:editResourceFromURI(\'' . (string)$resource . '\')'
+            );
+
+            // Delete resource option
+            $url = new OntoWiki_Url(
+                array('controller' => 'resource', 'action' => 'delete'),
+                array()
+            );
+
+            $url->setParam('r', $resource, true);
+            $resourceMenu->appendEntry('Delete Resource', (string)$url);
+        }
+
+        $resourceMenu->appendEntry(
+            'Go to Resource (external)',
+            (string)$resource
+        );
+
+        $resourceMenu->appendEntry(OntoWiki_Menu::SEPARATOR);
+
+        foreach (Erfurt_Syntax_RdfSerializer::getSupportedFormats() as $key => $format) {
+            $resourceMenu->appendEntry(
+                'Export Resource as ' . $format,
+                $config->urlBase . 'resource/export/f/' . $key . '?r=' . urlencode($resource)
+            );
+        }
+
+        return $resourceMenu;
+    }
+
+    /**
+     * Create the (context) menu for classes and fill it with its default entries
+     */
+    private function _getClassMenu($resource = null)
+    {
+        $owApp = OntoWiki::getInstance();
+        $classMenu = new OntoWiki_Menu();
+
+        $query     = Erfurt_Sparql_SimpleQuery::initWithString(
+            'SELECT *
+             FROM <' . (string)$owApp->selectedModel . '>
+             WHERE {
+                <' . $resource . '> a ?type  .
+             }'
+        );
+        $results[] = $owApp->erfurt->getStore()->sparqlQuery($query);
+
+        $query = Erfurt_Sparql_SimpleQuery::initWithString(
+            'SELECT *
+             FROM <' . (string)$owApp->selectedModel . '>
+             WHERE {
+                ?inst a <' . $resource . '> .
+             } LIMIT 2'
+        );
+
+        if (count($owApp->erfurt->getStore()->sparqlQuery($query)) > 0) {
+            $hasInstances = true;
+        } else {
+            $hasInstances = false;
+        }
+
+        $typeArray = array();
+        foreach ($results[0] as $row) {
+            $typeArray[] = $row['type'];
+        }
+
+        if (
+            in_array(EF_RDFS_CLASS, $typeArray)
+            || in_array(EF_OWL_CLASS, $typeArray)
+            || $hasInstances
+        ) {
+            $url = new OntoWiki_Url(
+                array('action' => 'list'),
+                array()
+            );
+            $url->setParam('class', $resource, false);
+            $url->setParam('init', "true", true);
+
+            $classMenu->appendEntry(
+                'List Instances',
+                (string)$url
+            );
+
+            // add class menu entries
+            if ($owApp->erfurt->getAc()->isModelAllowed('edit', $owApp->selectedModel)) {
+                $classMenu->appendEntry(
+                    'Create Instance',
+                    "javascript:createInstanceFromClassURI('$resource');"
+                );
+            }
+        }
+
+        return $classMenu;
+    }
 }
-
-

--- a/application/controllers/ResourceController.php
+++ b/application/controllers/ResourceController.php
@@ -49,18 +49,6 @@ class ResourceController extends OntoWiki_Controller_Base
 
         // add export formats to resource menu
         $resourceMenu = OntoWiki_Menu_Registry::getInstance()->getMenu('resource');
-        foreach (array_reverse(Erfurt_Syntax_RdfSerializer::getSupportedFormats()) as $key => $format) {
-            $resourceMenu->prependEntry(
-                'Export Resource as ' . $format,
-                $this->_config->urlBase . 'resource/export/f/' . $key . '?r=' . urlencode($resource)
-            );
-        }
-
-        $resourceMenu->prependEntry(OntoWiki_Menu::SEPARATOR);
-        $resourceMenu->prependEntry(
-            'Go to Resource (external)',
-            (string)$resource
-        );
 
         $menu = new OntoWiki_Menu();
         $menu->setEntry('Resource', $resourceMenu);

--- a/application/controllers/ServiceController.php
+++ b/application/controllers/ServiceController.php
@@ -124,200 +124,33 @@ class ServiceController extends Zend_Controller_Action
     {
         $module   = $this->_request->getParam('module');
         $resource = $this->_request->getParam('resource');
+        $model    = $this->_request->getParam('model');
 
         $translate = $this->_owApp->translate;
 
         // create empty menu first
         $menuRegistry = OntoWiki_Menu_Registry::getInstance();
-        $menu         = $menuRegistry->getMenu(EF_RDFS_RESOURCE);
+        if (!empty($resource)) {
+            $menu         = $menuRegistry->getMenu('resource', $resource);
+        } else if (!empty($model)) {
+            $menu         = $menuRegistry->getMenu('model', $model);
+        }
 
         if (!empty($module)) {
             $moduleRegistry = OntoWiki_Module_Registry::getInstance();
             $menu           = $moduleRegistry->getModule($module)->getContextMenu();
         }
 
-        if (!empty($resource)) {
-            $models  = array_keys($this->_owApp->erfurt->getStore()->getAvailableModels(true));
-            $isModel = in_array($resource, $models);
-
-            $menu->prependEntry(
-                'Go to Resource (external)',
-                (string)$resource
-            );
-
-            if ($this->_owApp->erfurt->getAc()->isModelAllowed('edit', $this->_owApp->selectedModel)) {
-                // Delete resource option
-                $url = new OntoWiki_Url(
-                    array('controller' => 'resource', 'action' => 'delete'),
-                    array()
-                );
-                if ($isModel) {
-                    $url->setParam('m', $resource, false);
-                }
-                $url->setParam('r', $resource, true);
-                $menu->prependEntry('Delete Resource', (string)$url);
-
-                // edit resource option
-                $menu->prependEntry('Edit Resource', 'javascript:editResourceFromURI(\'' . (string)$resource . '\')');
-            }
-
-            // add resource menu entries
-            $url = new OntoWiki_Url(
-                array('action' => 'view'),
-                array()
-            );
-            if ($isModel) {
-                $url->setParam('m', $resource, false);
-            }
-            $url->setParam('r', $resource, true);
-
-            $menu->prependEntry(
-                'View Resource',
-                (string)$url
-            );
-
-            if ($isModel) {
-                // add a seperator
-                $menu->prependEntry(OntoWiki_Menu::SEPARATOR);
-
-                // can user delete models?
-                if ($this->_owApp->erfurt->getAc()->isModelAllowed('edit', $resource)
-                    && $this->_owApp->erfurt->getAc()->isActionAllowed('ModelManagement')
-                ) {
-
-                    $url = new OntoWiki_Url(
-                        array('controller' => 'model', 'action' => 'delete'),
-                        array()
-                    );
-                    $url->setParam('model', $resource, false);
-
-                    $menu->prependEntry(
-                        'Delete Knowledge Base',
-                        (string)$url
-                    );
-                }
-
-                if ($this->_owApp->erfurt->getAc()->isActionAllowed(Erfurt_Ac_Default::ACTION_MODEL_EXPORT)) {
-                    // add entries for supported export formats
-                    foreach (array_reverse(Erfurt_Syntax_RdfSerializer::getSupportedFormats()) as $key => $format) {
-
-                        $url = new OntoWiki_Url(
-                            array('controller' => 'model', 'action' => 'export'),
-                            array()
-                        );
-                        $url->setParam('m', $resource, false);
-                        $url->setParam('f', $key);
-
-                        $menu->prependEntry(
-                            'Export Knowledge Base as ' . $format,
-                            (string)$url
-                        );
-                    }
-                }
-
-                // check if model could be edited (prefixes and data)
-                if ($this->_owApp->erfurt->getAc()->isModelAllowed('edit', $resource)) {
-
-                    $url = new OntoWiki_Url(
-                        array('controller' => 'model', 'action' => 'add'),
-                        array()
-                    );
-                    $url->setParam('m', $resource, false);
-                    $menu->prependEntry(
-                        'Add Data to Knowledge Base',
-                        (string)$url
-                    );
-
-                    $url = new OntoWiki_Url(
-                        array('controller' => 'model', 'action' => 'config'),
-                        array()
-                    );
-                    $url->setParam('m', $resource, false);
-                    $menu->prependEntry(
-                        'Configure Knowledge Base',
-                        (string)$url
-                    );
-                }
-
-                // Select Knowledge Base
-                $url = new OntoWiki_Url(
-                    array('controller' => 'model', 'action' => 'select'),
-                    array()
-                );
-                $url->setParam('m', $resource, false);
-                $menu->prependEntry(
-                    'Select Knowledge Base',
-                    (string)$url
-                );
-            } else {
-                $query     = Erfurt_Sparql_SimpleQuery::initWithString(
-                    'SELECT *
-                     FROM <' . (string)$this->_owApp->selectedModel . '>
-                     WHERE {
-                        <' . $resource . '> a ?type  .
-                     }'
-                );
-                $results[] = $this->_owApp->erfurt->getStore()->sparqlQuery($query);
-
-                $query = Erfurt_Sparql_SimpleQuery::initWithString(
-                    'SELECT *
-                     FROM <' . (string)$this->_owApp->selectedModel . '>
-                     WHERE {
-                        ?inst a <' . $resource . '> .
-                     } LIMIT 2'
-                );
-
-                if (count($this->_owApp->erfurt->getStore()->sparqlQuery($query)) > 0) {
-                    $hasInstances = true;
-                } else {
-                    $hasInstances = false;
-                }
-
-                $typeArray = array();
-                foreach ($results[0] as $row) {
-                    $typeArray[] = $row['type'];
-                }
-
-                if (in_array(EF_RDFS_CLASS, $typeArray) || in_array(EF_OWL_CLASS, $typeArray) || $hasInstances
-                ) {
-
-                    // add a seperator
-                    $menu->prependEntry(OntoWiki_Menu::SEPARATOR);
-
-                    $url = new OntoWiki_Url(
-                        array('action' => 'list'),
-                        array()
-                    );
-                    $url->setParam('class', $resource, false);
-                    $url->setParam('init', "true", true);
-
-                    // add class menu entries
-                    if ($this->_owApp->erfurt->getAc()->isModelAllowed('edit', $this->_owApp->selectedModel)) {
-                        $menu->prependEntry(
-                            'Create Instance',
-                            "javascript:createInstanceFromClassURI('$resource');"
-                        );
-                    }
-                    $menu->prependEntry(
-                        'List Instances',
-                        (string)$url
-                    );
-                    // ->prependEntry('Create Instance', $this->_config->urlBase . 'index/create/?r=')
-                    // ->prependEntry('Create Subclass', $this->_config->urlBase . 'index/create/?r=');
-                }
-            }
-        }
-
         // Fire a event;
         $event           = new Erfurt_Event('onCreateMenu');
         $event->menu     = $menu;
         $event->resource = $resource;
-
-        if (isset($isModel)) {
-            $event->isModel = $isModel;
+        if (!empty($model)) {
+            $event->isModel = true;
+            $event->model = $model;
+        } else {
+            $event->model = $this->_owApp->selectedModel;
         }
-
-        $event->model = $this->_owApp->selectedModel;
         $event->trigger();
 
         echo $menu->toJson();

--- a/extensions/themes/silverblue/scripts/support.js
+++ b/extensions/themes/silverblue/scripts/support.js
@@ -344,26 +344,32 @@ function showResourceMenu(event, json) {
             $('#' + menuId).fadeOut();
         }
     }
-    
+
     if(json == undefined){
+        var aboutUri, modelUri, resourceUri;
+
         // URI of the resource clicked (used attribute can be about and resource)
         if ( typeof $(event.target).parent().attr('about') != 'undefined' ) {
-            resourceUri = $(event.target).parent().attr('about');
+            aboutUri = $(event.target).parent().attr('about');
         } else if ( typeof $(event.target).parent().attr('resource') != 'undefined' ) {
-            resourceUri = $(event.target).parent().attr('resource');
-        } else {
-            // no usable resource uri, so we exit here
-            return false;
+            aboutUri = $(event.target).parent().attr('resource');
         }
 
-        encodedResourceUri = encodeURIComponent(resourceUri);
-        resource = $(event.target).parent();
-
-        
+        if (aboutUri == null) {
+            // no usable resource uri, so we exit here
+            return false;
+        } else if ($(event.target).parent().hasClass('Model')) {
+            modelUri = aboutUri;
+        } else {
+            resourceUri = aboutUri;
+        }
 
         var urlParams = {};
-        urlParams.resource = resourceUri;
-
+        if (modelUri != null) {
+            urlParams.model = modelUri;
+        } else {
+            urlParams.resource = resourceUri;
+        }
 
         // load menu with specific options from service
         $.ajax({


### PR DESCRIPTION
- Move registration of resource menue from controllers to menu-registry
- Introduce context param for getMenu and setMenu to allow the same menu in different context, e.g. resource-menu for different resources
- If resource entry has class Model send a model parameter
- If the css class of the dom node ist Model send model-paramter instead of resource-parameter to the service/menu action
- Change order of insertion to append
