### PR TITLE
update CodeSniffer Standard for Issue https://github.com/AKSW/OntoWiki/issues/249

### DIFF
--- a/application/tests/CodeSniffer/Standards/Ontowiki/Sniffs/ControlStructures/MultiLineConditionSniff.php
+++ b/application/tests/CodeSniffer/Standards/Ontowiki/Sniffs/ControlStructures/MultiLineConditionSniff.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * This file is part of the {@link http://ontowiki.net OntoWiki} project.
+ *
+ * @copyright Copyright (c) 2013, {@link http://aksw.org AKSW}
+ * @license   http://opensource.org/licenses/gpl-license.php GNU General Public License (GPL)
+ */
+ 
+/**
+ * Ontowiki_Sniffs_ControlStructures_MultiLineConditionSniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Lars Eidam <lars.eidam@googlemail.com>
+ * @link      http://code.google.com/p/ontowiki/
+ */
+
+/**
+ * Ontowiki_Sniffs_ControlStructures_MultiLineConditionSniff.
+ *
+ * Ensure multi-line IF conditions are defined correctly.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Lars Eidam <lars.eidam@googlemail.com>
+ * @link      http://code.google.com/p/ontowiki/
+ */
+class OntoWiki_Sniffs_ControlStructures_MultiLineConditionSniff implements PHP_CodeSniffer_Sniff
+{
+
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(
+                T_IF,
+                T_ELSEIF,
+               );
+
+    }//end register()
+
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token
+     *                                        in the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // We need to work out how far indented the if statement
+        // itself is, so we can work out how far to indent conditions.
+        $statementIndent = 0;
+        for ($i = ($stackPtr - 1); $i >= 0; $i--) {
+            if ($tokens[$i]['line'] !== $tokens[$stackPtr]['line']) {
+                $i++;
+                break;
+            }
+        }
+
+        if ($i >= 0 && $tokens[$i]['code'] === T_WHITESPACE) {
+            $statementIndent = strlen($tokens[$i]['content']);
+        }
+
+        // Each line between the parenthesis should be indented 4 spaces
+        // and start with an operator, unless the line is inside a
+        // function call, in which case it is ignored.
+        $openBracket  = $tokens[$stackPtr]['parenthesis_opener'];
+        $closeBracket = $tokens[$stackPtr]['parenthesis_closer'];
+        $lastLine     = $tokens[$openBracket]['line'];
+        $lineCount    = 0;
+        for ($i = ($openBracket + 1); $i < $closeBracket; $i++) {
+            if ($tokens[$i]['line'] !== $lastLine) {
+                $lineCount++;
+                if ($tokens[$i]['line'] !== $tokens[$closeBracket]['line']) {
+                    // check all lines exept the first, if there is a boolean operator at the beginning
+                    if (1 < $lineCount) {
+                        $next = $phpcsFile->findNext(T_WHITESPACE, $i, null, true);
+                        if (in_array($tokens[$next]['code'], PHP_CodeSniffer_Tokens::$booleanOperators) === false) {
+                            $error = 'Each line (except the first) in a multi-line IF statement must begin with a boolean operator';
+                            $phpcsFile->addError($error, $i, 'StartWithBoolean');
+                        }
+                    // check the first line, if there is no boolean operator in the whole line
+                    } else {
+                        $next = $phpcsFile->findNext(PHP_CodeSniffer_Tokens::$booleanOperators, $i, null, false);
+                        if ($tokens[$next]['line'] == $tokens[$i]['line']) {
+                            $error = 'The first line in a multi-line IF statement may have no boolean operator';
+                            $phpcsFile->addError($error, $i, 'FirstLineIncludeBoolean');
+                        }
+                    }
+                }
+
+                $lastLine = $tokens[$i]['line'];
+            }//end if
+
+            if ($tokens[$i]['code'] === T_STRING) {
+                $next = $phpcsFile->findNext(T_WHITESPACE, ($i + 1), null, true);
+                if ($tokens[$next]['code'] === T_OPEN_PARENTHESIS) {
+                    // This is a function call, so skip to the end as they
+                    // have their own indentation rules.
+                    $i        = $tokens[$next]['parenthesis_closer'];
+                    $lastLine = $tokens[$i]['line'];
+                    continue;
+                }
+            }
+        }//end for
+
+    }//end process()
+
+
+}//end class
+
+?>

--- a/application/tests/CodeSniffer/Standards/Ontowiki/ruleset.xml
+++ b/application/tests/CodeSniffer/Standards/Ontowiki/ruleset.xml
@@ -56,6 +56,9 @@
     <rule ref="PEAR.Commenting.InlineComment" />
     <rule ref="PEAR.ControlStructures.ControlSignature" />
     <rule ref="PEAR.ControlStructures.MultiLineCondition" />
+    <rule ref="PEAR.ControlStructures.MultiLineCondition.StartWithBoolean">
+        <exclude-pattern>*</exclude-pattern>
+    </rule>
     <!--<rule ref="PEAR.Files.IncludingFile" />-->
     <rule ref="PEAR.Formatting.MultiLineAssignment" />
     <rule ref="PEAR.Functions.FunctionCallSignature" />


### PR DESCRIPTION
- fix issue https://github.com/AKSW/OntoWiki/issues/249
- disable StartWithBoolean message in sniff PEAR.ControlStructures.MultiLineCondition
- add own implementation in sniff OntoWiki.ControlStructures.MultiLineCondition with messages StartWithBoolean and FirstLineIncludeBoolean
