### PR TITLE
Delete Resource Menu Button Fix

### DIFF
--- a/application/classes/OntoWiki/Menu/Registry.php
+++ b/application/classes/OntoWiki/Menu/Registry.php
@@ -347,10 +347,9 @@ class OntoWiki_Menu_Registry
             // Delete resource option
             $url = new OntoWiki_Url(
                 array('controller' => 'resource', 'action' => 'delete'),
-                array()
+                array('r')
             );
-
-            $url->setParam('r', $resource, true);
+            $url->setParam('r', (string)$resource, false);
             $resourceMenu->appendEntry('Delete Resource', (string)$url);
         }
 

--- a/application/controllers/ResourceController.php
+++ b/application/controllers/ResourceController.php
@@ -172,9 +172,14 @@ class ResourceController extends OntoWiki_Controller_Base
                 )
             );
             // ->appendButton(OntoWiki_Toolbar::EDITADD, array('name' => 'Add Property', 'class' => 'property-add'));
+            $url = new OntoWiki_Url(
+                array('controller' => 'resource', 'action' => 'delete'),
+                array('r')
+            );
+            $url->setParam('r', (string)$resource, false);
             $params = array(
                 'name' => 'Delete',
-                'url'  => $this->_config->urlBase . 'resource/delete/?r=' . urlencode((string)$resource)
+                'url'  => (string)$url
             );
             $toolbar->appendButton(OntoWiki_Toolbar::SEPARATOR);
             $toolbar->appendButton(OntoWiki_Toolbar::DELETE, $params);


### PR DESCRIPTION
The Menu Button 'Delete Resource' now uses the same way to produce the delete URL as the Toolbar Delete button does.

This is most likely not like it was intended (the use of the OntoWiki_Url class should be the correct way), but i couldn't find the direct source for the error in the OntoWiki_Url Class