### PR TITLE
Fix indention of array in FileCommentSniff

### DIFF
--- a/application/tests/CodeSniffer/Standards/Ontowiki/Sniffs/Commenting/FileCommentSniff.php
+++ b/application/tests/CodeSniffer/Standards/Ontowiki/Sniffs/Commenting/FileCommentSniff.php
@@ -26,14 +26,13 @@ class Ontowiki_Sniffs_Commenting_FileCommentSniff implements PHP_CodeSniffer_Sni
      * @var array
      */
     protected $_copyright = array(
-                            1  => "/**\n",
-                            2  => " * This file is part of the {@link http://ontowiki.net OntoWiki} project.\n",
-                            3  => " *\n",
-                            4  => "",
-                            5  => " * @license   http://opensource.org/licenses/gpl-license.php "
-                                . "GNU General Public License (GPL)\n",
-                            6  => " */",
-                           );
+        1  => "/**\n",
+        2  => " * This file is part of the {@link http://ontowiki.net OntoWiki} project.\n",
+        3  => " *\n",
+        4  => "",
+        5  => " * @license   http://opensource.org/licenses/gpl-license.php GNU General Public License (GPL)\n",
+        6  => " */",
+    );
 
     /**
      * Returns an array of tokens this test wants to listen for.


### PR DESCRIPTION
This should fix

```
Errors parsing /var/lib/jenkins/jobs/OntoWiki/workspace/application/tests/CodeSniffer/Standards/Ontowiki/Sniffs/Commenting/FileCommentSniff.php
PHP Parse error:  syntax error, unexpected '.', expecting ')' in /var/lib/jenkins/jobs/OntoWiki/workspace/application/tests/CodeSniffer/Standards/Ontowiki/Sniffs/Commenting/FileCommentSniff.php on line 34
```