### PR TITLE
Fix content-type for resource exports

### DIFF
--- a/application/classes/OntoWiki/Test/ControllerTestCase.php
+++ b/application/classes/OntoWiki/Test/ControllerTestCase.php
@@ -43,6 +43,8 @@ class OntoWiki_Test_ControllerTestCase extends Zend_Test_PHPUnit_ControllerTestC
         );
 
         parent::setUp();
+
+        $this->_storeAdapter = Erfurt_App::getInstance(false)->getStore()->getBackendAdapter();
     }
 
     public function setUpExtensionUnitTest()

--- a/application/classes/OntoWiki/Test/UnitTestBootstrap.php
+++ b/application/classes/OntoWiki/Test/UnitTestBootstrap.php
@@ -61,9 +61,20 @@ class OntoWiki_Test_UnitTestBootstrap extends Bootstrap
         );
         $erfurt->setStore($store);
 
+        $erfurt->setAc(new Erfurt_Ac_None());
+
         // make available
         $ontoWiki->erfurt = $erfurt;
 
         return $erfurt;
+    }
+
+    public function _initPlugins()
+    {
+        // require front controller
+        $this->bootstrap('frontController');
+        $frontController = $this->getResource('frontController');
+
+        // We do not register any plugins for unit tests.
     }
 }

--- a/application/controllers/ResourceController.php
+++ b/application/controllers/ResourceController.php
@@ -478,24 +478,9 @@ class ResourceController extends OntoWiki_Controller_Base
 
         $filename = 'export' . date('Y-m-d_Hi');
 
-        switch ($format) {
-            case 'rdfxml':
-                $contentType = 'application/rdf+xml';
-                $filename .= '.rdf';
-                break;
-            case 'rdfn3':
-                $contentType = 'text/rdf+n3';
-                $filename .= '.n3';
-                break;
-            case 'rdfjson':
-                $contentType = 'application/json';
-                $filename .= '.json';
-                break;
-            case 'turtle':
-                $contentType = 'application/x-turtle';
-                $filename .= '.ttl';
-                break;
-        }
+        $formatDescription = Erfurt_Syntax_RdfSerializer::getFormatDescription($format);
+        $contentType = $formatDescription['contentType'];
+        $filename .= $formatDescription['fileExtension'];
 
         /*
          * Event: allow for adding / deleting statements to the export

--- a/application/tests/unit/controller/ResourceControllerTest.php
+++ b/application/tests/unit/controller/ResourceControllerTest.php
@@ -23,71 +23,20 @@ class ResourceControllerTest extends OntoWiki_Test_ControllerTestCase
         $this->setUpUnitTest();
     }
 
-    public function testDummyTestUnlessNoWorkingActualTestExists()
+    public function testExportActionReturnsCorrectContentTypeForTurtle()
     {
-        $this->assertTrue(true);
+        $r = 'http://example.org/resource1';
+        $m = 'http://example.org/model1/';
+        $this->_storeAdapter->createModel($m);
+
+        $this->request->setParam('r', $r);
+        $this->request->setParam('m', $m);
+        $this->request->setParam('f', 'turtle');
+        $this->dispatch('/resource/export');
+
+        $this->assertController('resource');
+        $this->assertAction('export');
+        $this->assertResponseCode(200);
+        $this->assertHeaderContains('Content-Type', 'text/turtle');
     }
-
-    /*
-        public function testListInstantiation()
-        {
-            $this->request->setMethod('POST')
-                ->setPost(
-                array(
-                    'list' => 'instances',
-                    'init' => true,
-                )
-            );
-
-            $this->dispatch('/list');
-
-            $this->assertController('resource');
-            $this->assertAction('instances');
-            $this->assertResponseCode(200);
-        }
-
-
-        public function testListConfig()
-        {
-            $c = array(
-                'filter' => array(
-                    'action' => 'add',
-                    'mode' => 'box',
-                    'filter' => 'equals',
-                    'value' => 'http://test.com/'
-                )
-            );
-            $this->request->setMethod('POST')
-                ->setPost(
-                array(
-                    'list' => 'instances',
-                    'init' => true,
-                    'instancesconfig' => json_encode($c)
-                )
-            );
-
-            $this->dispatch('/list');
-
-            $this->assertController('resource');
-            $this->assertAction('instances');
-            $this->assertResponseCode(200);
-        }
-
-        public function testListError()
-        {
-            $c = array();
-            $this->request->setMethod('POST')
-                ->setPost(
-                array(
-                    'list' => 'newone',
-                    //no init parameter
-                    'instancesconfig' => json_encode($c)
-                )
-            );
-
-            $this->dispatch('/list');
-
-            $this->assertController('error');
-        }
-    */
 }


### PR DESCRIPTION
This is fixed by using the values provides by Erfurt_Syntax_RdfSerializer, which already include the correct values.