### PR TITLE
Repair the non-share save Query option

### DIFF
--- a/extensions/queries/resources/savepartial.js
+++ b/extensions/queries/resources/savepartial.js
@@ -22,7 +22,7 @@ $(document).ready(function() {
           success: function(msg){
            //TODO check for status
            if(msg != "All OK")
-            alert("Fehler "+msg);
+            alert("Error "+msg);
            //open(urlBase + "querybuilding/listquery");
           }
         });
@@ -46,8 +46,7 @@ $(document).ready(function() {
           name: $('#qname').val(),
           "query": editor.getValue(),
           generator: "qe",
-          //share: $("#savequerysharecheckbox").is(':checked') ? "true" : "false"
-          share: "true"
+          share: $("#savequerysharecheckbox").is(':checked') ? "true" : "false"
           }),
           dataType: "text",
                 error: function(xmlHttpObj, type, error){
@@ -56,7 +55,7 @@ $(document).ready(function() {
           success: function(msg){
            //TODO check for status
            if (msg != "All OK") {
-            alert("Fehler " + msg);
+            alert("Error " + msg);
            } else {
             $('.innercontent').prepend("<p class=\"messagebox info\" id=\"savequerynotification\">The Query was saved</p>");
             

--- a/extensions/queries/templates/savequery.phtml
+++ b/extensions/queries/templates/savequery.phtml
@@ -4,6 +4,6 @@
     </p><p>
     <input id="hidden_query" type="hidden"  value=""/>
     <input id="hidden_json" type="hidden" value=""/>
-    <input id="savequerysharecheckbox" type="checkbox"> share with others
+    <input id="savequerysharecheckbox" type="checkbox" checked> share with others
 </p>
 <a id = 'savequerybutton' class="button submit"><span><?php echo $this->_('Save Query'); ?></span></a>


### PR DESCRIPTION
This PR intends to fix the option to "not-share" private Queries in the Query Menu

The Option is in the Query Menu for a knowledge base. On the right side is a field to save a query with a checkbox to give the choice to share it or not. This checkbox had was ignored so far and checked or not didn't make a difference. All saved queries were saved in the same knowledge base and visible for everyone. 

I expected them to be only visible for the creator (if the box was checked prior to saving).

I just fixed the errors in the existing implementation (the button was only deactivated in the `extensions/queries/resources/savepartial.js`) and added a proper authentication check.

 Now it creates properly an extra knowledge base for the user queries if he doesn't want do share them. This doesn't seem to be supported in the extensions that work with saved queries though. Hence i would say that we should probably think how and If we want to support this feature and add support for it in the extensions, that work with saved queries as needed.