### PR TITLE
Integrate support for Stardog backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ help-test:
 	@echo "  test-unit .................... Run OntoWiki unit tests"
 	@echo "  test-integration-virtuoso .... Run OntoWiki integration tests with virtuoso"
 	@echo "  test-integration-mysql ....... Run OntoWiki integration tests with mysql"
+	@echo "  test-integration-stardog ..... Run OntoWiki integration tests with stardog"
 	@echo "  test-extensions .............. Run tests for extensions"
 
 getcomposer:
@@ -106,6 +107,9 @@ test-integration-virtuoso: test-directories
 test-integration-mysql: test-directories
 	EF_STORE_ADAPTER=zenddb $(PHPUNIT) --testsuite "OntoWiki Virtuoso Integration Tests"
 
+test-integration-stardog: test-directories
+	EF_STORE_ADAPTER=stardog $(PHPUNIT) --testsuite "OntoWiki Virtuoso Integration Tests"
+
 test-extensions: #directories
 	$(PHPUNIT) --testsuite "OntoWiki Extensions Tests"
 
@@ -119,6 +123,10 @@ test:
 	@echo "-----------------------------------"
 	@echo ""
 	make test-integration-mysql
+	@echo ""
+	@echo "-----------------------------------"
+	@echo ""
+	make test-integration-stardog
 	@echo ""
 	@echo "-----------------------------------"
 	@echo ""

--- a/application/classes/OntoWiki/Test/IntegrationTestBootstrap.php
+++ b/application/classes/OntoWiki/Test/IntegrationTestBootstrap.php
@@ -57,7 +57,14 @@ class OntoWiki_Test_IntegrationTestBootstrap extends Bootstrap
         // editing the config
         if ($config instanceof Zend_Config) {
             $storeAdapter = getenv('EF_STORE_ADAPTER');
-            if (($storeAdapter === 'virtuoso') || ($storeAdapter === 'zenddb')) {
+
+            $supportedStores = [
+                'virtuoso',
+                'zenddb',
+                'stardog'
+            ];
+
+            if (in_array($storeAdapter, $supportedStores)) {
                 $config->store->backend = $storeAdapter;
             } else {
                 if ($storeAdapter !== false) {

--- a/application/tests/config.ini.dist
+++ b/application/tests/config.ini.dist
@@ -15,3 +15,8 @@ store.zenddb.host     = localhost ; default is localhost
 store.virtuoso.dsn      = VOS_TEST ; needs to end with _TEST
 store.virtuoso.username = dba
 store.virtuoso.password = dba
+
+store.stardog.base_url = "http://localhost:5820"
+store.stardog.username = admin
+store.stardog.password = admin
+store.stardog.database = "ow_TEST"

--- a/config.ini.dist
+++ b/config.ini.dist
@@ -42,6 +42,14 @@ store.virtuoso.search_max_length_for_bifcontains = "4"
 ;store.virtuoso.use_persistent_connection = true
 
 ;;;;
+;; Stardog backend specific options
+;;
+store.stardog.base_url = "http://localhost:5820"
+store.stardog.username = admin
+store.stardog.password = admin
+store.stardog.database = "ontowiki"
+
+;;;;
 ;; ARC2 backend specific options
 ;;
 store.arc.dbname = "ontowiki_arc2"


### PR DESCRIPTION
- add default config values for stardog backend to config default
  files
- adjust integration test bootstrap to allow stardog backend
