### PR TITLE
composer.json: adding "prefer-stable": true let composer choose stable packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,5 +39,6 @@
             "application/controllers/"
         ]
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
With `"prefer-stable": true` in composer.json Composer will use stable versions rather than commits like `2.2.x-dev-...`.

After executing `composer update` using the changed composer.json i got the following output:

```
- Updating mnsami/composer-custom-directory-installer (dev-master 8cc82e0 => 1.1.0)
    Checking out 0d4a476e54063f0da191224a27e505f5ad6e15ff

  - Updating easyrdf/easyrdf (0.9.x-dev acd09df => 0.9.1)
    Checking out acd09dfe0555fbcfa254291e433c45fdd4652566

  - Updating zendframework/zendframework1 (dev-master a90f3a8 => 1.12.20)
    Checking out 737ef159654fbbef37cf9af742b2c8f9690c2ece

  - Updating semsol/arc2 (dev-master 89e3467 => 2.3.0)
    Checking out 1cba0487e764b4d7e22913e995f7525192a226c5

  - Removing aksw/erfurt (v1.8.0-rc.1)
  - Installing aksw/erfurt (v1.8.0)
    Loading from cache

  - Updating symfony/yaml (2.8.x-dev e754073 => v2.8.12)
    Checking out e7540734bad981fe59f8ef14b6fc194ae9df8d9c

  - Updating sebastian/recursion-context (dev-master 7ff5b1b => 1.0.2)
    Checking out 913401df809e99e4f47b27cdd781f4a258d58791

  - Updating sebastian/exporter (dev-master 42c4c2e => 1.2.2)
    Checking out 42c4c2eec485ee3e159ec9884f95b431287edde4

  - Updating sebastian/environment (1.3.x-dev be2c607 => 1.3.8)
    Checking out be2c607e43ce4c89ecd60e75c6a85c126e754aea

  - Updating sebastian/diff (dev-master 13edfd8 => 1.4.1)
    Checking out 13edfd8706462032c2f52b4b862974dd46b71c9e

  - Updating sebastian/comparator (dev-master 937efb2 => 1.2.0)
    Checking out 937efb279bd37a375bcadf584dec0726f84dbf22

  - Updating doctrine/instantiator (dev-master 416fb8a => 1.0.5)
    Checking out 8e884e78f9f0eb1329e445619e04456e64d8051d

  - Updating phpunit/phpunit-mock-objects (2.3.x-dev ac8e7a3 => 2.3.8)
    Checking out ac8e7a3db35738d56ee9a76e78a4e03d97628983

  - Updating phpunit/php-token-stream (dev-master cab6c6f => 1.4.8)
    Checking out 3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da

  - Updating phpunit/php-code-coverage (2.2.x-dev eabf68b => 2.2.4)
    Checking out eabf68b476ac7d0f73793aada060f1c1a9bf8979

  - Installing webmozart/assert (1.1.0)
    Loading from cache

  - Installing phpdocumentor/reflection-common (1.0)
    Loading from cache

  - Installing phpdocumentor/type-resolver (0.2)
    Loading from cache

  - Removing phpdocumentor/reflection-docblock (2.0.4)
  - Installing phpdocumentor/reflection-docblock (3.1.1)
    Loading from cache

  - Updating phpspec/prophecy (dev-master d3be829 => v1.6.1)
    Checking out 58a8137754bc24b25740d4281399a4a3596058e0

  - Updating phpunit/phpunit (4.5.x-dev d6429b0 => 4.5.1)
    Checking out d6429b0995b24a2d9dfe5587ee3a7071c1161af4

  - Removing squizlabs/php_codesniffer (dev-master a3cb316)
  - Installing squizlabs/php_codesniffer (dev-master 11d5cac)
    Cloning 11d5cac9b8a778baead1712692dd0ad5633f43d5
```

I guess thats the behavior you want for stable versions instead of using unstable commits.
