### PR TITLE
Repair deactivateRegistration .ini entry in Erfurt

### DIFF
--- a/application/classes/OntoWiki/Menu/Registry.php
+++ b/application/classes/OntoWiki/Menu/Registry.php
@@ -124,7 +124,8 @@ class OntoWiki_Menu_Registry
 
         // user sub menu
         if ($owApp->erfurt->isActionAllowed('RegisterNewUser')
-            && !(isset($owApp->config->ac) && ((boolean)$owApp->config->ac->deactivateRegistration === true))
+            && !(isset($owApp->config->ac)
+            && ((boolean)$owApp->config->ac->deactivateRegistration === true))
         ) {
 
             if (!($owApp->erfurt->getAc() instanceof Erfurt_Ac_None)) {

--- a/application/config/default.ini
+++ b/application/config/default.ini
@@ -92,6 +92,10 @@ descriptionHelper.properties.dcDesc2 = "http://purl.org/dc/elements/1.1/descript
 descriptionHelper.properties.skosNote = "http://www.w3.org/2004/02/skos/core#note"
 descriptionHelper.properties.skosEditorialNote = "http://www.w3.org/2004/02/skos/core#editorialNote"
 
+;;
+; AC settings
+;;
+;ac.deactivateRegistration = true
 
 ;;
 ; List settings

--- a/application/controllers/ApplicationController.php
+++ b/application/controllers/ApplicationController.php
@@ -197,6 +197,16 @@ class ApplicationController extends OntoWiki_Controller_Base
     public function registerAction()
     {
         OntoWiki::getInstance()->getNavigation()->disableNavigation();
+        //check if the Register Action is allowed
+        if (isset($this->_owApp->config->ac)
+            && ((boolean)$this->_owApp->config->ac->deactivateRegistration === true)
+        ) {
+            $this->_helper->viewRenderer->setNoRender();
+            $this->view->placeholder('main.window.title')->set('Register User');
+            $message = 'The registration is deactivated, please consult an Admin about this.';
+            $this->_owApp->appendMessage(new OntoWiki_Message($message, OntoWiki_Message::ERROR));
+            return;
+        }
         $this->_helper->viewRenderer->setScriptAction('register');
 
         $this->view->placeholder('main.window.title')->set('Register User');
@@ -359,7 +369,16 @@ class ApplicationController extends OntoWiki_Controller_Base
     public function openidregAction()
     {
         OntoWiki::getInstance()->getNavigation()->disableNavigation();
-
+        //check if the Register Action is allowed
+        if (isset($this->_owApp->config->ac)
+            && ((boolean)$this->_owApp->config->ac->deactivateRegistration === true)
+        ) {
+            $this->_helper->viewRenderer->setNoRender();
+            $this->view->placeholder('main.window.title')->set('Register User');
+            $message = 'The registration is deactivated, please consult an Admin about this.';
+            $this->_owApp->appendMessage(new OntoWiki_Message($message, OntoWiki_Message::ERROR));
+            return;
+        }
         // We render a template, that is also used for preferences.
         $this->_helper->viewRenderer->setScriptAction('openid');
 
@@ -550,7 +569,16 @@ class ApplicationController extends OntoWiki_Controller_Base
     public function webidregAction()
     {
         OntoWiki::getInstance()->getNavigation()->disableNavigation();
-
+        //check if the Register Action is allowed
+        if (isset($this->_owApp->config->ac)
+            && ((boolean)$this->_owApp->config->ac->deactivateRegistration === true)
+        ) {
+            $this->_helper->viewRenderer->setNoRender();
+            $this->view->placeholder('main.window.title')->set('Register User');
+            $message = 'The registration is deactivated, please consult an Admin about this.';
+            $this->_owApp->appendMessage(new OntoWiki_Message($message, OntoWiki_Message::ERROR));
+            return;
+        }
         // We render a template, that is also used for preferences.
         $this->_helper->viewRenderer->setScriptAction('webid');
 

--- a/extensions/account/LoginModule.php
+++ b/extensions/account/LoginModule.php
@@ -60,7 +60,10 @@ class LoginModule extends OntoWiki_Module
             'redirectUri' => urlencode((string)$url)
         );
 
-        if ($this->_erfurt->getAc()->isActionAllowed('RegisterNewUser')) {
+        if ($this->_erfurt->getAc()->isActionAllowed('RegisterNewUser')
+            && !(isset($this->_owApp->config->ac)
+            && ((boolean)$this->_owApp->config->ac->deactivateRegistration === true))
+        ) {
             $data['showRegisterButton']      = true;
             $data['registerActionUrl']       = $this->_config->urlBase . 'application/register';
             $data['openIdRegisterActionUrl'] = $this->_config->urlBase . 'application/openidreg';


### PR DESCRIPTION
This pull request repairs the functionality of the deactivateRegistration option in the config.ini in Erfurt.
Though I'm unsure why the Erfurt config entries don't seem to get merged into the big OntoWiki config file.

Fixes #390 
