### PR TITLE
Set the Config in the OntoWiki_View constructor

### DIFF
--- a/application/classes/OntoWiki/View.php
+++ b/application/classes/OntoWiki/View.php
@@ -67,7 +67,7 @@ class OntoWiki_View extends Zend_View
     public function __construct($config = array(), $translate = null)
     {
         parent::__construct($config);
-
+        $this->_config              = OntoWiki::getInstance()->config;
         $this->_translate           = $translate;
         $this->_placeholderRegistry = Zend_View_Helper_Placeholder_Registry::getRegistry();
 


### PR DESCRIPTION
This pull request sets the `$_config` variable in the View, with this the config entry cache.modules stops throwing a fatal error (#386)