### PR TITLE
add orderby for the limit offset test

### DIFF
--- a/application/tests/integration/OntoWiki/Model/InstancesIntegrationTest.php
+++ b/application/tests/integration/OntoWiki/Model/InstancesIntegrationTest.php
@@ -183,6 +183,7 @@ class OntoWiki_Model_InstancesIntegrationTest extends Erfurt_TestCase
      */
     public function testLimitOffset()
     {
+        $this->_instances->orderByUri();
         $this->_instances->addTypeFilter($this->_class);
         $this->assertCount(2, $this->_instances->getResources());
         $this->_instances->setLimit(1);


### PR DESCRIPTION
This ORDER BY is necessary for the Virtuoso 7.x back-end to work again :man_facepalming: 